### PR TITLE
Fix a mac drag problem related to trackpad

### DIFF
--- a/src/UI_Slider.cpp
+++ b/src/UI_Slider.cpp
@@ -105,6 +105,14 @@ void SliderWrapper::mouseUp(const juce::MouseEvent &e_)
 
 void SliderWrapper::mouseWheelMove(const juce::MouseEvent &e_, const juce::MouseWheelDetails &w_)
 {
+    /*
+     * MACOS Trackpad on a two-finger gesture to drag (which is the RMB gesture) will
+     * generate a 0-distance drag event also, which looks like a move, setting this timer
+     * in a way which conflicts with the drag.
+     */
+    if (abs(w_.deltaY) + abs(w_.deltaY) < 0.0001)
+        return;
+
     if (!GLOBAL_VALUE_HOLDER::getInstance()->ENABLE_MOUSEWHEEL)
         return;
 


### PR DESCRIPTION
The "RMB Drag" gesture on a mac trackpad is two fingers down,
click, drag. Cool. But 2 fingers down can also begin a wheel event.
The mac trackpad is smart enough to not send any motion but it does
generate a zero distance wheel event which B-Step picks up and uses
to interfere with the drag event. So don't start the wheel timer on
a zero distance wheel event.

Closes #22