### PR TITLE
Add CLAP to windows installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13 CACHE STRING "Minimum macOS version")
 project("B-Step" VERSION 2.1.0 LANGUAGES C CXX ASM)
 
 # Calculate bitness
-math(EXPR BSTEP_BITNESS "${CMAKE_SIZEOF_VOID_P} * 8" OUTPUT_FORMAT DECIMAL)
-message(STATUS "Targeting ${BSTEP_BITNESS}-bit configuration")
+math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
+message(STATUS "Targeting ${BITS}-bit configuration")
 
 option(BSTEP_COPY_PLUGIN_AFTER_BUILD "Copy JUCE Plugins after built" OFF)
 option(BSTEP_RELIABLE_VERSION_INFO "Update version info on every build (off: generate only at configuration time)" ON)

--- a/cmake/basic-installer.cmake
+++ b/cmake/basic-installer.cmake
@@ -41,10 +41,10 @@ if (WIN32)
             POST_BUILD
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
             COMMAND ${CMAKE_COMMAND} -E echo "Cleaning up windows goobits"
-            COMMAND ${CMAKE_COMMAND} -E rm -f "${BSTEP_PRODUCT_DIR}/Shortcircuit XT.exp"
-            COMMAND ${CMAKE_COMMAND} -E rm -f "${BSTEP_PRODUCT_DIR}/Shortcircuit XT.ilk"
-            COMMAND ${CMAKE_COMMAND} -E rm -f "${BSTEP_PRODUCT_DIR}/Shortcircuit XT.lib"
-            COMMAND ${CMAKE_COMMAND} -E rm -f "${BSTEP_PRODUCT_DIR}/Shortcircuit XT.pdb"
+            COMMAND ${CMAKE_COMMAND} -E rm -f "${BSTEP_PRODUCT_DIR}/B-Step.exp"
+            COMMAND ${CMAKE_COMMAND} -E rm -f "${BSTEP_PRODUCT_DIR}/B-Step.ilk"
+            COMMAND ${CMAKE_COMMAND} -E rm -f "${BSTEP_PRODUCT_DIR}/B-Step.lib"
+            COMMAND ${CMAKE_COMMAND} -E rm -f "${BSTEP_PRODUCT_DIR}/B-Step.pdb"
             )
 endif ()
 
@@ -74,7 +74,6 @@ endif ()
 
 string(TIMESTAMP BSTEP_DATE "%Y-%m-%d")
 if (WIN32)
-    math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
     set(BSTEP_ZIP BStep-${BSTEP_DATE}-${VERSION_CHUNK}-${CMAKE_SYSTEM_NAME}-${BITS}bit.zip)
 else ()
     set(BSTEP_ZIP BStep-${BSTEP_DATE}-${VERSION_CHUNK}-${CMAKE_SYSTEM_NAME}.zip)
@@ -101,15 +100,15 @@ elseif (WIN32)
             COMMAND ${CMAKE_COMMAND} -E echo "ZIP Installer in: installer/${BSTEP_ZIP}")
     find_program(BSTEP_NUGET_EXE nuget.exe PATHS ENV "PATH")
     if(BSTEP_NUGET_EXE)
-        message(STATUS "NuGet found at ${BSTEP_NUGET_EXE}, creating InnoSetup installer")
+        message(STATUS "NuGet found at ${BSTEP_NUGET_EXE}")
         add_custom_command(
             TARGET bstep-installer
             POST_BUILD
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             COMMAND ${BSTEP_NUGET_EXE} install Tools.InnoSetup -version 6.2.0
-            COMMAND Tools.InnoSetup.6.2.0/tools/iscc.exe /O"installer" /DBSTEP_SRC="${CMAKE_SOURCE_DIR}" /DBSTEP_BIN="${CMAKE_BINARY_DIR}" /DBSTEP_VERSION="${BSTEP_DATE}-${VERSION_CHUNK}" "${CMAKE_SOURCE_DIR}/resources/installer_win/bstep${BSTEP_BITNESS}.iss")
+            COMMAND Tools.InnoSetup.6.2.0/tools/iscc.exe /O"installer" /DBSTEP_SRC="${CMAKE_SOURCE_DIR}" /DBSTEP_BIN="${CMAKE_BINARY_DIR}" /DBSTEP_VERSION="${BSTEP_DATE}-${VERSION_CHUNK}" "${CMAKE_SOURCE_DIR}/resources/installer_win/bstep${BITS}.iss")
     else()
-        message(STATUS "NuGet not found, not creating InnoSetup installer")
+        message(STATUS "NuGet not found")
     endif()
 else ()
     message(STATUS "Basic Installer: Target is installer/${BSTEP_ZIP}")

--- a/resources/installer_win/bstep32.iss
+++ b/resources/installer_win/bstep32.iss
@@ -11,8 +11,8 @@
 [Setup]
 AppId={#MyID}
 AppName={#MyAppName}
+AppVerName={#MyAppName}
 AppVersion={#BSTEP_VERSION}
-AppVerName={#MyAppName} {#BSTEP_VERSION}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
@@ -23,13 +23,13 @@ DisableDirPage=yes
 DisableProgramGroupPage=yes
 AlwaysShowDirOnReadyPage=yes
 LicenseFile={#BSTEP_SRC}\LICENSE-gpl3
-OutputBaseFilename={#MyAppName}-win32-{#BSTEP_VERSION}-setup
+OutputBaseFilename={#MyAppNameCondensed}-{#BSTEP_VERSION}-Windows-32bit-setup
 SetupIconFile={#BSTEP_SRC}\resources\installer_win\bstep.ico
 UninstallDisplayIcon={uninstallexe}
 UsePreviousAppDir=yes
 Compression=lzma
 SolidCompression=yes
-UninstallFilesDir={autoappdata}\{#MyAppName}\uninstall
+UninstallFilesDir={app}\uninstall
 CloseApplicationsFilter=*.exe,*.vst3
 WizardStyle=modern
 WizardSizePercent=100
@@ -42,17 +42,20 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Types]
 Name: "full"; Description: "Full installation"
-Name: "plugin"; Description: "VST3 installation"
+Name: "vst3"; Description: "VST3 installation"
+Name: "clap"; Description: "CLAP installation"
 Name: "standalone"; Description: "Standalone installation"
 Name: "custom"; Description: "Custom"; Flags: iscustom
 
 [Components]
-Name: "vst3"; Description: "{#MyAppNameCondensed} VST3 (32-bit)"; Types: full plugin custom
-Name: "exe"; Description: "{#MyAppNameCondensed} Standalone (32-bit)"; Types: full standalone custom
+Name: "VST3"; Description: "{#MyAppName} VST3 (32-bit)"; Types: full vst3 custom
+Name: "CLAP"; Description: "{#MyAppName} CLAP (32-bit)"; Types: full clap custom
+Name: "SA"; Description: "{#MyAppName} Standalone (32-bit)"; Types: full standalone custom
 
 [Files]
-Source: "{#BSTEP_BIN}\bstep-products\{#MyAppName}.exe"; DestDir: "{app}"; Components: exe; Flags: ignoreversion
-Source: "{#BSTEP_BIN}\bstep-products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppName}.vst3\"; Components: vst3; Flags: ignoreversion recursesubdirs
+Source: "{#BSTEP_BIN}\bstep-products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppPublisher}\{#MyAppName}.vst3\"; Components: VST3; Flags: ignoreversion recursesubdirs
+Source: "{#BSTEP_BIN}\bstep-products\{#MyAppName}.clap"; DestDir: "{autocf}\Clap\{#MyAppPublisher}\"; Components: CLAP; Flags: ignoreversion
+Source: "{#BSTEP_BIN}\bstep-products\{#MyAppName}.exe"; DestDir: "{app}"; Components: SA; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppName}.exe"; Flags: createonlyiffileexists

--- a/resources/installer_win/bstep64.iss
+++ b/resources/installer_win/bstep64.iss
@@ -13,8 +13,8 @@ ArchitecturesInstallIn64BitMode=x64
 ArchitecturesAllowed=x64
 AppId={#MyID}
 AppName={#MyAppName}
+AppVerName={#MyAppName}
 AppVersion={#BSTEP_VERSION}
-AppVerName={#MyAppName} {#BSTEP_VERSION}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
@@ -25,13 +25,13 @@ DisableDirPage=yes
 DisableProgramGroupPage=yes
 AlwaysShowDirOnReadyPage=yes
 LicenseFile={#BSTEP_SRC}\LICENSE-gpl3
-OutputBaseFilename={#MyAppName}-win64-{#BSTEP_VERSION}-setup
+OutputBaseFilename={#MyAppNameCondensed}-{#BSTEP_VERSION}-Windows-64bit-setup
 SetupIconFile={#BSTEP_SRC}\resources\installer_win\bstep.ico
 UninstallDisplayIcon={uninstallexe}
 UsePreviousAppDir=yes
 Compression=lzma
 SolidCompression=yes
-UninstallFilesDir={autoappdata}\{#MyAppName}\uninstall
+UninstallFilesDir={app}\uninstall
 CloseApplicationsFilter=*.exe,*.vst3
 WizardStyle=modern
 WizardSizePercent=100
@@ -44,17 +44,20 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Types]
 Name: "full"; Description: "Full installation"
-Name: "plugin"; Description: "VST3 installation"
+Name: "vst3"; Description: "VST3 installation"
+Name: "clap"; Description: "CLAP installation"
 Name: "standalone"; Description: "Standalone installation"
 Name: "custom"; Description: "Custom"; Flags: iscustom
 
 [Components]
-Name: "vst3"; Description: "{#MyAppNameCondensed} VST3 (64-bit)"; Types: full plugin custom
-Name: "exe"; Description: "{#MyAppNameCondensed} Standalone (64-bit)"; Types: full standalone custom
+Name: "VST3"; Description: "{#MyAppName} VST3 (64-bit)"; Types: full vst3 custom
+Name: "CLAP"; Description: "{#MyAppName} CLAP (64-bit)"; Types: full clap custom
+Name: "SA"; Description: "{#MyAppName} Standalone (64-bit)"; Types: full standalone custom
 
 [Files]
-Source: "{#BSTEP_BIN}\bstep-products\{#MyAppName}.exe"; DestDir: "{app}"; Components: exe; Flags: ignoreversion
-Source: "{#BSTEP_BIN}\bstep-products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppName}.vst3\"; Components: vst3; Flags: ignoreversion recursesubdirs
+Source: "{#BSTEP_BIN}\bstep-products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppPublisher}\{#MyAppName}.vst3\"; Components: VST3; Flags: ignoreversion recursesubdirs
+Source: "{#BSTEP_BIN}\bstep-products\{#MyAppName}.clap"; DestDir: "{autocf}\Clap\{#MyAppPublisher}\"; Components: CLAP; Flags: ignoreversion
+Source: "{#BSTEP_BIN}\bstep-products\{#MyAppName}.exe"; DestDir: "{app}"; Components: SA; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppName}.exe"; Flags: createonlyiffileexists


### PR DESCRIPTION
- Fix windows cleanup stage
- Clear up language for NUGET search
(we don't actually create installer at this stage)
- Remove redundant bitness check
- Fix installer exe name to match zip installer
- Fix AppVerName to match Surge installer
- Better uninstaller location
- Make sure we install in publisher folders with Surge